### PR TITLE
Add Polymarket market fetch script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
 # market2
+
+This repository contains utilities for working with [Polymarket](https://polymarket.com).
+
+## Setup
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Retrieving Recent Markets
+
+`get_recent_markets.py` fetches all markets created in the last 24 hours using Polymarket's public API.
+
+Run the script with:
+
+```bash
+python get_recent_markets.py
+```
+
+The output lists market IDs, their slugs, and creation times. The script can be
+imported as a module for further processing.

--- a/get_recent_markets.py
+++ b/get_recent_markets.py
@@ -1,0 +1,50 @@
+import requests
+from datetime import datetime, timedelta, timezone
+
+API_URL = "https://client-api.polymarket.com/graphql"
+
+QUERY = """
+query($after: Int!) {
+  markets(
+    limit: 100,
+    sortBy: "creationTime",
+    sortDirection: "desc",
+    filter: {creationTime: {gt: $after}}
+  ) {
+    id
+    slug
+    question
+    description
+    category
+    subcategory
+    outcomeType
+    volume
+    liquidity
+    creationTime
+    url
+  }
+}
+"""
+
+def get_recent_markets(hours=24):
+    """Return markets created within the last `hours` hours."""
+    created_after = int((datetime.now(timezone.utc) - timedelta(hours=hours)).timestamp())
+    payload = {
+        "query": QUERY,
+        "variables": {"after": created_after},
+    }
+
+    response = requests.post(API_URL, json=payload)
+    response.raise_for_status()
+    data = response.json()
+    return data["data"]["markets"]
+
+
+def main():
+    markets = get_recent_markets()
+    for market in markets:
+        print(f"{market['id']}: {market['slug']} (created {market['creationTime']})")
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pandas
 numpy
+requests


### PR DESCRIPTION
## Summary
- add `get_recent_markets.py` for retrieving newly opened markets
- update README with setup and usage instructions
- add `requests` to requirements

## Testing
- `python -m py_compile get_recent_markets.py`
- `pytest -q`
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement requests)*

------
https://chatgpt.com/codex/tasks/task_e_684696f79de4832ab62e06143ddecb7d