### PR TITLE
Fix Polymarket fetch script

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ pip install -r requirements.txt
 
 ## Retrieving Recent Markets
 
-`get_recent_markets.py` fetches all markets created in the last 24 hours using Polymarket's public API.
+`get_recent_markets.py` fetches all markets created in the last 24 hours using Polymarket's public API. The script defaults to the new GraphQL endpoint `https://api.polymarket.xyz/graphql`. Set the `POLYMARKET_API_URL` environment variable to override the endpoint if it changes again.
 
 Run the script with:
 


### PR DESCRIPTION
## Summary
- update Polymarket API endpoint and allow override via `POLYMARKET_API_URL`
- handle network errors gracefully
- document new API URL in README

## Testing
- `python -m py_compile get_recent_markets.py`
- `python get_recent_markets.py | head -n 5` *(fails: Tunnel connection failed: 403 Forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_6846991eea04832aab43df8f45e87056