### PR TITLE
Improve Polymarket API fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ pip install -r requirements.txt
 
 ## Retrieving Recent Markets
 
-`get_recent_markets.py` fetches all markets created in the last 24 hours using Polymarket's public API. The script defaults to the new GraphQL endpoint `https://api.polymarket.xyz/graphql`. Set the `POLYMARKET_API_URL` environment variable to override the endpoint if it changes again.
+`get_recent_markets.py` fetches all markets created in the last 24 hours using Polymarket's public API. The tool now tries a small list of known endpoints and will automatically fall back if the first one fails. You can override the list by setting the `POLYMARKET_API_URL` environment variable to a preferred endpoint.
 
 Run the script with:
 


### PR DESCRIPTION
## Summary
- update README about automatic fallback to alternative endpoints
- add fallback API endpoints in `get_recent_markets.py`

## Testing
- `python -m py_compile get_recent_markets.py`
- `python get_recent_markets.py | head -n 5` *(fails: 405 Client Error)*

------
https://chatgpt.com/codex/tasks/task_e_68469cbd5e1c832ab259c4c55a08994b