### PR TITLE
Add FastAPI server and frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,16 @@ python get_recent_markets.py
 
 The output lists market IDs, their slugs, and creation times. The script can be
 imported as a module for further processing.
+
+## Web Interface
+
+A small FastAPI app exposes recent Polymarket markets and serves a simple HTML
+page that lists the last 50 markets in a table.
+
+Start the development server with:
+
+```bash
+uvicorn app:app --reload
+```
+
+Then open `http://localhost:8000/` in your browser.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,28 @@
+from typing import List, Dict
+
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import HTMLResponse
+from fastapi.staticfiles import StaticFiles
+
+from get_recent_markets import fetch_latest
+
+app = FastAPI(title="Polymarket Recent Markets")
+
+
+@app.get("/api/markets")
+def get_markets(limit: int = 50) -> List[Dict]:
+    """Return the newest Polymarket markets."""
+    try:
+        return fetch_latest(limit)
+    except Exception as exc:
+        raise HTTPException(status_code=502, detail=str(exc))
+
+
+app.mount("/static", StaticFiles(directory="static"), name="static")
+
+
+@app.get("/", response_class=HTMLResponse)
+def index() -> str:
+    """Serve the front-end HTML page."""
+    with open("static/index.html", "r", encoding="utf-8") as fh:
+        return fh.read()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 pandas
 numpy
 requests
+
+fastapi
+uvicorn[standard]

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Recent Polymarket Markets</title>
+    <style>
+        table { border-collapse: collapse; width: 100%; }
+        th, td { border: 1px solid #ccc; padding: 4px; text-align: left; }
+    </style>
+</head>
+<body>
+    <h1>Last 50 Polymarket Markets</h1>
+    <table id="markets">
+        <thead>
+            <tr>
+                <th>ID</th>
+                <th>Title</th>
+                <th>Slug</th>
+                <th>Created</th>
+            </tr>
+        </thead>
+        <tbody></tbody>
+    </table>
+    <script>
+        async function loadMarkets() {
+            try {
+                const response = await fetch('/api/markets?limit=50');
+                const data = await response.json();
+                const tbody = document.querySelector('#markets tbody');
+                data.forEach(mkt => {
+                    const row = document.createElement('tr');
+                    row.innerHTML = `<td>${mkt.id}</td><td>${mkt.title}</td><td>${mkt.slug}</td><td>${mkt.createdAt}</td>`;
+                    tbody.appendChild(row);
+                });
+            } catch (err) {
+                console.error('Failed to load markets', err);
+            }
+        }
+        loadMarkets();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create `app.py` FastAPI backend exposing `/api/markets`
- add simple HTML frontend under `static/`
- document web interface and FastAPI usage in README
- update requirements with `fastapi` and `uvicorn`

## Testing
- `pip install -r requirements.txt`
- `python - <<'EOF'
import app
print('app loaded', bool(app.app))
EOF
`
- `python get_recent_markets.py 1 --raw | head -c 100`

------
https://chatgpt.com/codex/tasks/task_e_6846a82a5d9c832a8659ce20a88ae3f3