### PR TITLE
Enable in-app FastAPI server

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,4 +34,10 @@ Start the development server with:
 uvicorn app:app --reload
 ```
 
+Or simply run the application module directly:
+
+```bash
+python app.py
+```
+
 Then open `http://localhost:8000/` in your browser.

--- a/app.py
+++ b/app.py
@@ -26,3 +26,16 @@ def index() -> str:
     """Serve the front-end HTML page."""
     with open("static/index.html", "r", encoding="utf-8") as fh:
         return fh.read()
+
+
+if __name__ == "__main__":
+    import os
+    import uvicorn
+
+    port = int(os.getenv("PORT", "8000"))
+    uvicorn.run(
+        "app:app",
+        host="0.0.0.0",
+        port=port,
+        reload=True,
+    )


### PR DESCRIPTION
## Summary
- auto-start Uvicorn when running `app.py`
- document that `python app.py` can launch the web interface

## Testing
- `python -m py_compile app.py get_recent_markets.py`
- `python app.py --help` *(shows server starting)*

------
https://chatgpt.com/codex/tasks/task_e_6846aa8c6e08832ab92717668d3d8e2f