### PR TITLE
Add numeric market ID support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,17 @@ python app.py
 ```
 
 Then open `http://localhost:8000/` in your browser.
+
+## Checking Market Prices
+
+`market_prices.py` prints the best bid and ask for each outcome of a Polymarket
+market. The script accepts either a full condition ID (the long hexadecimal
+string used by the CLOB API) or the shorter numeric market ID that appears in
+the Polymarket UI. When a numeric ID is provided, the tool searches the most
+recent markets using `get_recent_markets.py` to resolve it to the corresponding
+condition ID.
+
+```bash
+python market_prices.py 550868      # numeric ID
+python market_prices.py 0xabc...    # condition ID
+```


### PR DESCRIPTION
## Summary
- allow `market_prices.py` to accept short numeric market IDs
- fetch recent markets to resolve numeric ID to `conditionId`
- document how to use `market_prices.py` with either ID format

## Testing
- `python -m py_compile market_prices.py get_recent_markets.py app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846f110b744832aad14c03003290775