### PR TITLE
Add market slug lookup feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,16 @@ python get_recent_markets.py
 The output lists market IDs, their slugs, and creation times. The script can be
 imported as a module for further processing.
 
+To resolve a market's numeric ID when you only know its slug, use the
+``--find-id`` option:
+
+```bash
+python get_recent_markets.py --find-id mlb-wsh-nym-2025-06-10
+```
+
+This searches the most recent markets (use ``--limit`` to adjust the window)
+and prints the ID if a match is found.
+
 ## Web Interface
 
 A small FastAPI app exposes recent Polymarket markets and serves a simple HTML

--- a/market_prices.py
+++ b/market_prices.py
@@ -34,11 +34,10 @@ def _auth_client() -> ClobClient:
 
 
 def _resolve_market_id(market_id: str, *, search_limit: int = 100) -> str:
-    """Return the condition ID for *market_id*.
+    """Return the condition ID for ``market_id``.
 
-    If *market_id* already looks like a hex condition ID it is returned as-is.
-    Otherwise the most recent markets are searched using ``fetch_latest`` and
-    the matching entry's ``conditionId`` value is returned.
+    ``market_id`` may be a full condition ID, a numeric market ID, or a slug.
+    The most recent markets are searched when resolution is required.
     """
 
     if market_id.startswith("0x"):
@@ -46,10 +45,14 @@ def _resolve_market_id(market_id: str, *, search_limit: int = 100) -> str:
 
     markets = fetch_latest(search_limit)
     for market in markets:
-        if str(market.get("id")) == str(market_id):
+        if str(market.get("id")) == str(market_id) or market.get("slug") == market_id:
+            if market.get("slug") == market_id:
+                print(f"Slug '{market_id}' -> market ID {market.get('id')}")
             return market.get("conditionId")
 
-    raise RuntimeError(f"Market {market_id} not found in last {search_limit} markets")
+    raise RuntimeError(
+        f"Market {market_id} not found in last {search_limit} markets"
+    )
 
 def print_bid_ask(market_id: str) -> None:
     """Fetch market and print best bid and ask for each outcome."""


### PR DESCRIPTION
## Summary
- enable looking up a numeric market ID by slug
- expose `--find-id` option in `get_recent_markets.py`
- resolve slugs automatically in `market_prices.py`
- document slug lookup in README

## Testing
- `python -m py_compile get_recent_markets.py market_prices.py app.py polymarket_test`
- `python get_recent_markets.py --help | head -n 20`
- `python get_recent_markets.py --find-id blasttv-austin-major-stage-2-furia-vs-b8`
- `python market_prices.py --help | head -n 20` *(fails: ModuleNotFoundError: No module named 'py_clob_client')*

------
https://chatgpt.com/codex/tasks/task_e_6846f370ce30832a8c71ef23750c8cfe