### PR TITLE
Fix best price calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,9 @@ Then open `http://localhost:8000/` in your browser.
 ## Checking Market Prices
 
 `market_prices.py` prints the best bid and ask for each outcome of a Polymarket
-market. The script accepts either a full condition ID (the long hexadecimal
+market. Bids and asks returned from the API are sorted from *worst* to *best*,
+so the script looks at the last entry in each list to report the true best
+prices. The script accepts either a full condition ID (the long hexadecimal
 string used by the CLOB API) or the shorter numeric market ID that appears in
 the Polymarket UI. When a numeric ID is provided, the tool searches the most
 recent markets using `get_recent_markets.py` to resolve it to the corresponding

--- a/market_prices.py
+++ b/market_prices.py
@@ -64,8 +64,9 @@ def print_bid_ask(market_id: str) -> None:
         token_id = token.get("token_id")
         outcome = token.get("outcome", "")
         book = client.get_order_book(token_id)
-        best_bid: Optional[str] = book.bids[0].price if book.bids else None
-        best_ask: Optional[str] = book.asks[0].price if book.asks else None
+        # Bids and asks are sorted worst-to-best so use the last entry
+        best_bid: Optional[str] = book.bids[-1].price if book.bids else None
+        best_ask: Optional[str] = book.asks[-1].price if book.asks else None
         print(f"Outcome '{outcome}': bid={best_bid}, ask={best_ask}")
 
 


### PR DESCRIPTION
## Summary
- pick last entries in order book arrays to get best bid and ask
- clarify behaviour in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846fb4e97f8832ab8ee693418c9ad33