### PR TITLE
Fix repeated hedging orders

### DIFF
--- a/trading_helpers.py
+++ b/trading_helpers.py
@@ -39,6 +39,21 @@ def get_positions(market: str) -> Dict[str, float]:
     return positions
 
 
+def get_token_outcomes(market: str) -> Dict[str, str]:
+    """Return mapping from token ID to outcome name for ``market``."""
+    client = _auth_client()
+    condition_id = _resolve_market_id(market)
+    market_info = client.get_market(condition_id)
+
+    outcomes: Dict[str, str] = {}
+    for token in market_info.get("tokens", []):
+        token_id = token.get("token_id")
+        outcome = token.get("outcome", "").lower()
+        if token_id is not None:
+            outcomes[str(token_id)] = outcome
+    return outcomes
+
+
 def get_open_orders(market: str) -> List[Dict[str, Any]]:
     """Return open orders for *market* with a valid ``size`` field."""
     client = _auth_client()


### PR DESCRIPTION
## Summary
- add `get_token_outcomes` helper to map token ids to outcomes
- avoid duplicate buy orders in `hedge_once`

## Testing
- `python -m py_compile robot_v2.py trading_helpers.py`

------
https://chatgpt.com/codex/tasks/task_e_684a9c5b4038832aae7ec519769b0ec1